### PR TITLE
Bump copyright year to 2022

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Vaticle
+   Copyright 2022 Vaticle
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/dependencies/vaticle/BUILD
+++ b/dependencies/vaticle/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -25,7 +25,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "515d6adf719cc7e78f9d313e6c97bce9f918b60b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "57617a9978129f5d6b50f69146caaa9e86c3c85e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_client_python():

--- a/deployment.bzl
+++ b/deployment.bzl
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/BUILD
+++ b/kglib/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/__init__.py
+++ b/kglib/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_data_loader/BUILD
+++ b/kglib/kgcn_data_loader/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_data_loader/dataset/typedb_networkx_dataset.py
+++ b/kglib/kgcn_data_loader/dataset/typedb_networkx_dataset.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_data_loader/encoding/standard_encode.py
+++ b/kglib/kgcn_data_loader/encoding/standard_encode.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_data_loader/encoding/standard_encode_test.py
+++ b/kglib/kgcn_data_loader/encoding/standard_encode_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_data_loader/transform/standard_kgcn_transform.py
+++ b/kglib/kgcn_data_loader/transform/standard_kgcn_transform.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_data_loader/utils.py
+++ b/kglib/kgcn_data_loader/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_data_loader/utils_test.py
+++ b/kglib/kgcn_data_loader/utils_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/.images/BUILD
+++ b/kglib/kgcn_tensorflow/.images/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/BUILD
+++ b/kglib/kgcn_tensorflow/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/examples/diagnosis/.images/BUILD
+++ b/kglib/kgcn_tensorflow/examples/diagnosis/.images/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/examples/diagnosis/BUILD
+++ b/kglib/kgcn_tensorflow/examples/diagnosis/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/examples/diagnosis/diagnosis.py
+++ b/kglib/kgcn_tensorflow/examples/diagnosis/diagnosis.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/examples/diagnosis/diagnosis_test.py
+++ b/kglib/kgcn_tensorflow/examples/diagnosis/diagnosis_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/learn/BUILD
+++ b/kglib/kgcn_tensorflow/learn/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/learn/feed.py
+++ b/kglib/kgcn_tensorflow/learn/feed.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/learn/learn.py
+++ b/kglib/kgcn_tensorflow/learn/learn.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/learn/learn_IT.py
+++ b/kglib/kgcn_tensorflow/learn/learn_IT.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/learn/loss.py
+++ b/kglib/kgcn_tensorflow/learn/loss.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/learn/metrics.py
+++ b/kglib/kgcn_tensorflow/learn/metrics.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/learn/metrics_test.py
+++ b/kglib/kgcn_tensorflow/learn/metrics_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/models/BUILD
+++ b/kglib/kgcn_tensorflow/models/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/models/attribute.py
+++ b/kglib/kgcn_tensorflow/models/attribute.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/models/attribute_IT.py
+++ b/kglib/kgcn_tensorflow/models/attribute_IT.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/models/attribute_test.py
+++ b/kglib/kgcn_tensorflow/models/attribute_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/models/core.py
+++ b/kglib/kgcn_tensorflow/models/core.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/models/core_IT.py
+++ b/kglib/kgcn_tensorflow/models/core_IT.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/models/embedding.py
+++ b/kglib/kgcn_tensorflow/models/embedding.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/models/embedding_IT.py
+++ b/kglib/kgcn_tensorflow/models/embedding_IT.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/models/embedding_test.py
+++ b/kglib/kgcn_tensorflow/models/embedding_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/models/typewise.py
+++ b/kglib/kgcn_tensorflow/models/typewise.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/models/typewise_IT.py
+++ b/kglib/kgcn_tensorflow/models/typewise_IT.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/models/typewise_test.py
+++ b/kglib/kgcn_tensorflow/models/typewise_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/pipeline/BUILD
+++ b/kglib/kgcn_tensorflow/pipeline/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/pipeline/pipeline.py
+++ b/kglib/kgcn_tensorflow/pipeline/pipeline.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/plot/BUILD
+++ b/kglib/kgcn_tensorflow/plot/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/plot/draw.py
+++ b/kglib/kgcn_tensorflow/plot/draw.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/plot/plotting.py
+++ b/kglib/kgcn_tensorflow/plot/plotting.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/kgcn_tensorflow/plot/plotting_test.py
+++ b/kglib/kgcn_tensorflow/plot/plotting_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/tests/deployment/BUILD
+++ b/kglib/tests/deployment/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/tests/deployment/kgcn/diagnosis.py
+++ b/kglib/tests/deployment/kgcn/diagnosis.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/tests/deployment/requirements.txt
+++ b/kglib/tests/deployment/requirements.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/tests/end_to_end/BUILD
+++ b/kglib/tests/end_to_end/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/tests/end_to_end/kgcn/diagnosis.py
+++ b/kglib/tests/end_to_end/kgcn/diagnosis.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/tests/end_to_end/kgcn/diagnosis_debug.py
+++ b/kglib/tests/end_to_end/kgcn/diagnosis_debug.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/BUILD
+++ b/kglib/utils/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/__init__.py
+++ b/kglib/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/graph/BUILD
+++ b/kglib/utils/graph/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/graph/iterate.py
+++ b/kglib/utils/graph/iterate.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/graph/query/BUILD
+++ b/kglib/utils/graph/query/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/graph/query/query_graph.py
+++ b/kglib/utils/graph/query/query_graph.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/graph/query/query_graph_test.py
+++ b/kglib/utils/graph/query/query_graph_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/graph/test/BUILD
+++ b/kglib/utils/graph/test/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/graph/test/case.py
+++ b/kglib/utils/graph/test/case.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/graph/thing/BUILD
+++ b/kglib/utils/graph/thing/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/graph/thing/concept_dict_to_graph_test.py
+++ b/kglib/utils/graph/thing/concept_dict_to_graph_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/graph/thing/concept_dict_to_networkx_graph.py
+++ b/kglib/utils/graph/thing/concept_dict_to_networkx_graph.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/graph/thing/queries_to_networkx_graph.py
+++ b/kglib/utils/graph/thing/queries_to_networkx_graph.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/graph/thing/queries_to_networkx_graph_it.py
+++ b/kglib/utils/graph/thing/queries_to_networkx_graph_it.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/graph/thing/queries_to_networkx_graph_test.py
+++ b/kglib/utils/graph/thing/queries_to_networkx_graph_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/test/BUILD
+++ b/kglib/utils/test/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/test/utils.py
+++ b/kglib/utils/test/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/BUILD
+++ b/kglib/utils/typedb/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/object/BUILD
+++ b/kglib/utils/typedb/object/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/object/thing.py
+++ b/kglib/utils/typedb/object/thing.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/synthetic/BUILD
+++ b/kglib/utils/typedb/synthetic/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/synthetic/examples/BUILD
+++ b/kglib/utils/typedb/synthetic/examples/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/synthetic/examples/diagnosis/generate.py
+++ b/kglib/utils/typedb/synthetic/examples/diagnosis/generate.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/synthetic/examples/diagnosis/schema.tql
+++ b/kglib/utils/typedb/synthetic/examples/diagnosis/schema.tql
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/synthetic/examples/diagnosis/seed_data.tql
+++ b/kglib/utils/typedb/synthetic/examples/diagnosis/seed_data.tql
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/synthetic/statistics/BUILD
+++ b/kglib/utils/typedb/synthetic/statistics/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/synthetic/statistics/pmf.py
+++ b/kglib/utils/typedb/synthetic/statistics/pmf.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/synthetic/statistics/pmf_test.py
+++ b/kglib/utils/typedb/synthetic/statistics/pmf_test.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/test/BUILD
+++ b/kglib/utils/typedb/test/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/test/base.py
+++ b/kglib/utils/typedb/test/base.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/test/mock/answer.py
+++ b/kglib/utils/typedb/test/mock/answer.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/test/mock/concept.py
+++ b/kglib/utils/typedb/test/mock/concept.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/type/BUILD
+++ b/kglib/utils/typedb/type/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/kglib/utils/typedb/type/type.py
+++ b/kglib/utils/typedb/type/type.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 Vaticle
+#  Copyright (C) 2022 Vaticle
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Vaticle
+# Copyright (C) 2022 Vaticle
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
## What is the goal of this PR?

We update the copyright header year to 2022.

## What are the changes implemented in this PR?

Bump the vaticle-dependencies commit & replace the year 2021 with 2022 in each copyright header.